### PR TITLE
Add `ThreadingUtilities.launch` for a simpler API

### DIFF
--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -26,7 +26,7 @@ jobs:
           - x64
           - x86
         exclusive:
-          - 'false'
+          - '0'
         os:
           - ubuntu-latest
           - macOS-latest
@@ -41,7 +41,7 @@ jobs:
           - os: macOS-latest
             arch: x86 # 32-bit Julia binaries are not available on macOS
         include:
-          - exclusive: 'true'
+          - exclusive: '1'
             threads: '2'
             arch: x64
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - x64
           - x86
         exclusive:
-          - 'false'
+          - '0'
         os:
           - ubuntu-latest
           - macOS-latest
@@ -40,12 +40,12 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86 # 32-bit Julia binaries are not available on macOS
-        #include:
-        #  - exclusive: 'true'
-        #    threads: '2'
-        #    arch: x64
-        #    os: ubuntu-latest
-        #    version: '1'
+        include:
+          - exclusive: '1'
+            threads: '2'
+            arch: x64
+            os: ubuntu-latest
+            version: '1'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,12 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86 # 32-bit Julia binaries are not available on macOS
-        include:
-          - exclusive: 'true'
-            threads: '2'
-            arch: x64
-            os: ubuntu-latest
-            version: '1'
+        #include:
+        #  - exclusive: 'true'
+        #    threads: '2'
+        #    arch: x64
+        #    os: ubuntu-latest
+        #    version: '1'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreadingUtilities"
 uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ThreadingUtilities
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://chriselrod.github.io/ThreadingUtilities.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://chriselrod.github.io/ThreadingUtilities.jl/dev)
-[![Continuous Integration](https://github.com/chriselrod/ThreadingUtilities.jl/workflows/CI/badge.svg)](https://github.com/chriselrod/ThreadingUtilities.jl/actions?query=workflow%3ACI)
-[![Continuous Integration (Julia nightly)](https://github.com/chriselrod/ThreadingUtilities.jl/workflows/CI%20(Julia%20nightly)/badge.svg)](https://github.com/chriselrod/ThreadingUtilities.jl/actions?query=workflow%3A%22CI+%28Julia+nightly%29%22)
-[![Coverage](https://codecov.io/gh/chriselrod/ThreadingUtilities.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/chriselrod/ThreadingUtilities.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaSIMD.github.io/ThreadingUtilities.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaSIMD.github.io/ThreadingUtilities.jl/dev)
+[![Continuous Integration](https://github.com/JuliaSIMD/ThreadingUtilities.jl/workflows/CI/badge.svg)](https://github.com/JuliaSIMD/ThreadingUtilities.jl/actions?query=workflow%3ACI)
+[![Continuous Integration (Julia nightly)](https://github.com/JuliaSIMD/ThreadingUtilities.jl/workflows/CI%20(Julia%20nightly)/badge.svg)](https://github.com/JuliaSIMD/ThreadingUtilities.jl/actions?query=workflow%3A%22CI+%28Julia+nightly%29%22)
+[![Coverage](https://codecov.io/gh/JuliaSIMD/ThreadingUtilities.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaSIMD/ThreadingUtilities.jl)
 
 Utilities for low overhead threading in Julia.
 
-Please see the [documentation](https://chriselrod.github.io/ThreadingUtilities.jl/stable).
+Please see the [documentation](https://JuliaSIMD.github.io/ThreadingUtilities.jl/stable).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,11 +4,11 @@ using Documenter
 makedocs(;
     modules=[ThreadingUtilities],
     authors="Chris Elrod <elrodc@gmail.com> and contributors",
-    repo="https://github.com/chriselrod/ThreadingUtilities.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/JuliaSIMD/ThreadingUtilities.jl/blob/{commit}{path}#L{line}",
     sitename="ThreadingUtilities.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://chriselrod.github.io/ThreadingUtilities.jl",
+        canonical="https://JuliaSIMD.github.io/ThreadingUtilities.jl",
         assets=String[],
     ),
     pages=[
@@ -20,5 +20,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/chriselrod/ThreadingUtilities.jl",
+    repo="github.com/JuliaSIMD/ThreadingUtilities.jl",
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,8 +4,8 @@ CurrentModule = ThreadingUtilities
 
 # ThreadingUtilities
 
-[ThreadingUtilities](https://github.com/chriselrod/ThreadingUtilities.jl)
+[ThreadingUtilities](https://github.com/JuliaSIMD/ThreadingUtilities.jl)
 provides utilities for low overhead threading in Julia.
 
 The source code for this package is available in the
-[GitHub repository](https://github.com/chriselrod/ThreadingUtilities.jl).
+[GitHub repository](https://github.com/JuliaSIMD/ThreadingUtilities.jl).

--- a/src/ThreadingUtilities.jl
+++ b/src/ThreadingUtilities.jl
@@ -7,8 +7,6 @@ using VectorizationBase:
     SPIN = 0   # 0: spinning
     WAIT = 1   # 1: waiting, check if ≤ 1 to see if task is free and waiting
     TASK = 2   # 2: task available
-    LOCK = 3   # 3: lock
-    STUP = 4   # 4: problem being setup. Any reason to have two lock flags?
 end
 const TASKS = Task[]
 const THREADBUFFERSIZE = 512

--- a/src/atomics.jl
+++ b/src/atomics.jl
@@ -48,6 +48,8 @@ for op ∈ ["xchg", "add", "sub", "and", "nand", "or", "xor", "max", "min", "uma
         end
     end
 end
+@inline _atomic_state(ptr::Ptr{UInt}) = reinterpret(ThreadState, _atomic_load(ptr))
+@inline _atomic_store!(ptr::Ptr{UInt}, x::ThreadState) = _atomic_store!(ptr, reinterpret(UInt, x))
 @inline function _atomic_cas_cmp!(ptr::Ptr{UInt}, cmp::ThreadState, newval::ThreadState)
     _atomic_cas_cmp!(ptr, reinterpret(UInt, cmp), reinterpret(UInt, newval))
 end

--- a/test/staticarrays.jl
+++ b/test/staticarrays.jl
@@ -18,32 +18,13 @@ function setup_mul_svector!(p, y::Base.RefValue{SVector{N,T}}, x::Base.RefValue{
     ThreadingUtilities.store!(p, (py,px), offset)
 end
 
-@inline function launch_thread_mul_svector_v1!(tid, y, x)
-    p = ThreadingUtilities.taskpointer(tid)
-    setup_mul_svector!(p, y, x)
-    while true
-        if ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.SPIN, ThreadingUtilities.TASK)
-            break
-        elseif ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.WAIT, ThreadingUtilities.LOCK)
-            ThreadingUtilities.wake_thread!(tid % UInt)
-            break
-        end
-        ThreadingUtilities.pause()
-    end
-end
-@inline function launch_thread_mul_svector_v2!(tid, y, x)
-    p = ThreadingUtilities.taskpointer(tid)
-    setup_mul_svector!(p, y, x)
-    # state = reinterpret(ThreadingUtilities.ThreadState, unsafe_load(p))
-    if ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.SPIN, ThreadingUtilities.TASK)
-        nothing
-    else
-        ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.WAIT, ThreadingUtilities.LOCK)
-        ThreadingUtilities.wake_thread!(tid % UInt)
+@inline function launch_thread_mul_svector(tid, y, x)
+    ThreadingUtilities.launch(tid, y, x) do p, y, x
+        setup_mul_svector!(p, y, x)
     end
 end
 
-function mul_svector_threads(f!::F, a::SVector{N,T}, b::SVector{N,T}, c::SVector{N,T}) where {F,N,T}
+function mul_svector_threads(a::SVector{N,T}, b::SVector{N,T}, c::SVector{N,T}) where {N,T}
     ra = Ref(a)
     rb = Ref(b)
     rc = Ref(c)
@@ -51,30 +32,26 @@ function mul_svector_threads(f!::F, a::SVector{N,T}, b::SVector{N,T}, c::SVector
     ry = Ref{SVector{N,T}}()
     rz = Ref{SVector{N,T}}()
     GC.@preserve ra rb rc rx ry rz begin
-        f!(1, rx, ra)
-        f!(2, ry, rb)
-        f!(3, rz, rc)
+        launch_thread_mul_svector(1, rx, ra)
+        launch_thread_mul_svector(2, ry, rb)
+        launch_thread_mul_svector(3, rz, rc)
         w = muladd.(2.7, a, b)
-        ThreadingUtilities.__wait(1)
-        ThreadingUtilities.__wait(2)
-        ThreadingUtilities.__wait(3)
+        ThreadingUtilities.wait(1)
+        ThreadingUtilities.wait(2)
+        ThreadingUtilities.wait(3)
     end
     rx[],ry[],rz[],w
 end
-mul_svector_threads_v1(a, b, c) = mul_svector_threads(launch_thread_mul_svector_v1!, a, b, c)
-mul_svector_threads_v2(a, b, c) = mul_svector_threads(launch_thread_mul_svector_v2!, a, b, c)
 
 @testset "SVector Test" begin
     a = @SVector rand(16);
     b = @SVector rand(16);
     c = @SVector rand(16);
-    w1,x1,y1,z1 = mul_svector_threads_v1(a, b, c)
-    w2,x2,y2,z2 = mul_svector_threads_v2(a, b, c)
-    @test iszero(@allocated mul_svector_threads_v1(a, b, c))
-    @test iszero(@allocated mul_svector_threads_v2(a, b, c))
-    @test w1 == w2 == a*2.7
-    @test x1 == x2 == b*2.7
-    @test y1 == y2 == c*2.7
-    @test z1 ≈ z2 ≈ muladd(2.7, a, b)
+    w,x,y,z = mul_svector_threads(a, b, c)
+    @test iszero(@allocated mul_svector_threads(a, b, c))
+    @test w == a*2.7
+    @test x == b*2.7
+    @test y == c*2.7
+    @test z ≈ muladd(2.7, a, b)
 end
 


### PR DESCRIPTION
Simpler API, and also faster than the way I was doing it before.

On my laptop, brought this down from about 370 ns to <300ns:
```julia
using ThreadingUtilities, StaticArrays, Test

struct MulStaticArray{P} end

function (::MulStaticArray{P})(p::Ptr{UInt}) where {P}
    _, (ptry,ptrx) = ThreadingUtilities.load(p, P, 2*sizeof(UInt))
    unsafe_store!(ptry, unsafe_load(ptrx) * 2.7)
    nothing
end

@generated function mul_staticarray_ptr(::A, ::B) where {A,B}
    c = MulStaticArray{Tuple{A,B}}()
    :(@cfunction($c, Cvoid, (Ptr{UInt},)))
end


@inline function setup_mul_svector!(p, y::Base.RefValue{SVector{N,T}}, x::Base.RefValue{SVector{N,T}}) where {N,T}
    py = Base.unsafe_convert(Ptr{SVector{N,T}}, y)
    px = Base.unsafe_convert(Ptr{SVector{N,T}}, x)
    fptr = mul_staticarray_ptr(py, px)
    offset = ThreadingUtilities.store!(p, fptr, sizeof(UInt))
    ThreadingUtilities.store!(p, (py,px), offset)
end


@inline function launch_thread_mul_svector(tid, y, x)
    ThreadingUtilities.launch(tid, y, x) do p, y, x
        setup_mul_svector!(p, y, x)
    end
end

function mul_svector_threads(a::SVector{N,T}, b::SVector{N,T}, c::SVector{N,T}) where {N,T}
    ra = Ref(a)
    rb = Ref(b)
    rc = Ref(c)
    rx = Ref{SVector{N,T}}()
    ry = Ref{SVector{N,T}}()
    rz = Ref{SVector{N,T}}()
    GC.@preserve ra rb rc rx ry rz begin
        launch_thread_mul_svector(1, rx, ra)
        launch_thread_mul_svector(2, ry, rb)
        launch_thread_mul_svector(3, rz, rc)
        w = muladd.(2.7, a, b)
        ThreadingUtilities.wait(1)
        ThreadingUtilities.wait(2)
        ThreadingUtilities.wait(3)
    end
    rx[],ry[],rz[],w
end


a = @SVector rand(16);
b = @SVector rand(16);
c = @SVector rand(16);

w1,x1,y1,z1 = mul_svector_threads(a, b, c);

@test w1 == a*2.7
@test x1 == b*2.7
@test y1 == c*2.7

@test z1 ≈ muladd(2.7, a, b)

@benchmark mul_svector_threads($(Ref(a))[], $(Ref(b))[], $(Ref(c))[])
```