### PR TITLE
Store and load each element of every tuple individually

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ThreadingUtilities"
 uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -91,12 +91,11 @@ end
     push!(q.args, :(i, $tup))
     q
 end
-@generated store!(p::Ptr{UInt}, tup::T, i) where {T<:Tuple} = :(_store!(p, tup, i))
-@inline function _store!(p::Ptr{UInt}, tup::Tuple{A,B,Vararg{Any,N}}, i) where {A,B,N}
+@inline function store!(p::Ptr{UInt}, tup::Tuple{A,B,Vararg{Any,N}}, i) where {A,B,N}
     i = store!(p, first(tup), i)
-    _store!(p, Base.tail(tup), i)
+    store!(p, Base.tail(tup), i)
 end
-@inline function _store!(p::Ptr{UInt}, tup::Tuple{A}, i) where {A}
+@inline function store!(p::Ptr{UInt}, tup::Tuple{A}, i) where {A}
     store!(p, first(tup), i)
 end
 @inline store!(p::Ptr{UInt}, tup::Tuple{}, i) = i

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -81,7 +81,6 @@ end
 end
 
 @generated function load(p::Ptr{UInt}, ::Type{T}, i) where {T<:Tuple}
-    isbitstype(T) || return :(i + $(sizeof(T)), load(p + i, $T))
     q = Expr(:block, Expr(:meta,:inline))
     tup = Expr(:tuple)
     for (i,t) ∈ enumerate(T.parameters)
@@ -92,7 +91,7 @@ end
     push!(q.args, :(i, $tup))
     q
 end
-@generated store!(p::Ptr{UInt}, tup::T, i) where {T<:Tuple} = isbitstype(T) ? :(_store!(p, tup, i)) : :(store!(p+i, tup); i + sizeof(tup))
+@generated store!(p::Ptr{UInt}, tup::T, i) where {T<:Tuple} = :(_store!(p, tup, i))
 @inline function _store!(p::Ptr{UInt}, tup::Tuple{A,B,Vararg{Any,N}}, i) where {A,B,N}
     i = store!(p, first(tup), i)
     _store!(p, Base.tail(tup), i)

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -6,5 +6,9 @@
         t1 = (1.0, C_NULL, 3, ThreadingUtilities.stridedpointer(x))
         @test ThreadingUtilities.store!(pointer(x), t1, 0) === mapreduce(sizeof, +, t1)
         @test ThreadingUtilities.load(pointer(x), typeof(t1), 0) === (mapreduce(sizeof, +, t1), t1)
+
+        nt1 = (;a = 1.0)
+        @test ThreadingUtilities.store!(pointer(x), nt1, 0) === sizeof(nt1)
+        @test ThreadingUtilities.load(pointer(x), typeof(nt1), 0) === (sizeof(nt1), nt1)
     end
 end

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -3,12 +3,8 @@
     @test ThreadingUtilities.store!(pointer(UInt[]), nothing, 1) == 1
     x = zeros(UInt, 100);
     GC.@preserve x begin
-        t1 = (1.0, "hello world", 3, [1,2,3,4])
-        @test ThreadingUtilities.store!(pointer(x), t1, 0) === sizeof(t1)
-        @test ThreadingUtilities.load(pointer(x), typeof(t1), 0) === (sizeof(t1), t1)
-        
-        t2 = (1.0, C_NULL, 3, ThreadingUtilities.stridedpointer(x))
-        @test ThreadingUtilities.store!(pointer(x), t2, 0) === mapreduce(sizeof, +, t2)
-        @test ThreadingUtilities.load(pointer(x), typeof(t2), 0) === (mapreduce(sizeof, +, t2), t2)
+        t1 = (1.0, C_NULL, 3, ThreadingUtilities.stridedpointer(x))
+        @test ThreadingUtilities.store!(pointer(x), t1, 0) === mapreduce(sizeof, +, t1)
+        @test ThreadingUtilities.load(pointer(x), typeof(t1), 0) === (mapreduce(sizeof, +, t1), t1)
     end
 end


### PR DESCRIPTION
As per [this discussion](https://github.com/JuliaSIMD/CheapThreads.jl/issues/4), it is beneficial to store the element of every tuple individually, regardless of `isbits` or not.

This currently fails one test:

https://github.com/JuliaSIMD/ThreadingUtilities.jl/blob/445f957e7fbaab582dcd65a759b8dd7e4c9996b1/test/internals.jl#L6-L8

Because the `array` is no longer stored within the `tuple` and the pointer type is invalid:

```Julia
julia> ThreadingUtilities.store!(pointer(x), [1.0,2.0], 0)
ERROR: pointerset: invalid pointer type
```

Do you expect to be able to store an array directly like this, or should `StrideArrays` really be used?