### PR TITLE
Reset threads on error

### DIFF
--- a/src/ThreadingUtilities.jl
+++ b/src/ThreadingUtilities.jl
@@ -30,21 +30,13 @@ include("atomics.jl")
 include("threadtasks.jl")
 include("warnings.jl")
 
-function initialize_task(tid::Int)
+function initialize_task(tid)
   _atomic_store!(taskpointer(tid), WAIT)
   t = Task(ThreadTask(taskpointer(tid)));
   t.sticky = true # create and pin
   # set to tid, we have tasks 2...nthread, from 1-based ind perspective
   ccall(:jl_set_task_tid, Cvoid, (Any, Cint), t, tid % Cint)
   TASKS[tid] = t
-end
-function reinitialize_tasks!(verbose::Bool = true)
-  for (tid,t) ∈ enumerate(TASKS)
-    if istaskfailed(t)
-      verbose && dump(t)
-      initialize_task(tid)
-    end
-  end
 end
 
 function __init__()

--- a/test/threadingutilities.jl
+++ b/test/threadingutilities.jl
@@ -38,13 +38,13 @@ function test_copy(tid, N = 100_000)
     GC.@preserve a b c x y z begin
         launch_thread_copy!(tid, x, a)
         yield()
-        ThreadingUtilities.wait(tid)
+        @assert !ThreadingUtilities.wait(tid)
         launch_thread_copy!(tid, y, b)
         yield()
-        ThreadingUtilities.wait(tid)
+        @assert !ThreadingUtilities.wait(tid)
         launch_thread_copy!(tid, z, c)
         yield()
-        ThreadingUtilities.wait(tid)
+        @assert !ThreadingUtilities.wait(ThreadingUtilities.taskpointer(tid))
     end
     @test a == x
     @test b == y
@@ -76,7 +76,7 @@ end
   end
   yield()
   @test all(istaskfailed, ThreadingUtilities.TASKS)
-  ThreadingUtilities.reinitialize_tasks!(false)
+  @test all(ThreadingUtilities.wait, eachindex(ThreadingUtilities.TASKS))
   @test !any(istaskfailed, ThreadingUtilities.TASKS)
   # test copy on the reinitialized tasks
   foreach(test_copy, eachindex(ThreadingUtilities.TASKS))


### PR DESCRIPTION
@efaulhaber @ranocha, `Polyester.jl` should perhaps check whether `wait` returns `true`, and if so throw after it finishes freeing the workers.

With this PR, it should at least print the errors.
I'm not a fan of dumping the `task` here, because printing can make threaded code hang. Thus, currently, getting errors in nested threaded code isn't supported, but that's at least a step up from not supporting errors in threaded code at all.