### PR TITLE
atomics: update llvmcall to use opaque pointers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ ManualMemory = "d125e4d3-2237-4719-b19c-fa641b8a4667"
 [compat]
 Aqua = "0.5"
 ManualMemory = "0.1.1"
-julia = "1.5"
+julia = "1.11"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/atomics.jl
+++ b/src/atomics.jl
@@ -1,23 +1,21 @@
+
 for (ityp,jtyp) ∈ [("i8", UInt8), ("i16", UInt16), ("i32", UInt32), ("i64", UInt64), ("i128", UInt128)]
     @eval begin
         @inline function _atomic_load(ptr::Ptr{$jtyp})
             Base.llvmcall($("""
-              %p = inttoptr i$(8sizeof(Int)) %0 to $(ityp)*
-              %v = load atomic $(ityp), $(ityp)* %p acquire, align $(Base.gc_alignment(jtyp))
+              %v = load atomic $(ityp), ptr %0 acquire, align $(Base.gc_alignment(jtyp))
               ret $(ityp) %v
             """), $jtyp, Tuple{Ptr{$jtyp}}, ptr)
         end
         @inline function _atomic_store!(ptr::Ptr{$jtyp}, x::$jtyp)
             Base.llvmcall($("""
-              %p = inttoptr i$(8sizeof(Int)) %0 to $(ityp)*
-              store atomic $(ityp) %1, $(ityp)* %p release, align $(Base.gc_alignment(jtyp))
+              store atomic $(ityp) %1, ptr %0 release, align $(Base.gc_alignment(jtyp))
               ret void
             """), Cvoid, Tuple{Ptr{$jtyp}, $jtyp}, ptr, x)
         end
         @inline function _atomic_cas_cmp!(ptr::Ptr{$jtyp}, cmp::$jtyp, newval::$jtyp)
             Base.llvmcall($("""
-              %p = inttoptr i$(8sizeof(Int)) %0 to $(ityp)*
-              %c = cmpxchg $(ityp)* %p, $(ityp) %1, $(ityp) %2 acq_rel acquire
+              %c = cmpxchg ptr %0, $(ityp) %1, $(ityp) %2 acq_rel acquire
               %bit = extractvalue { $ityp, i1 } %c, 1
               %bool = zext i1 %bit to i8
               ret i8 %bool


### PR DESCRIPTION
Changes:
- Use `ptr` for opaque pointers with `llvmcall`
- Need Julia 1.11+:
    We need LLVM 15+ for pointer type `ptr` and Julia 1.11+ for opaque-pointers mode.
    See: [Pointer Type - LLVM 15](https://releases.llvm.org/15.0.0/docs/LangRef.html#t-pointer);
    [Bump Julia to LLVM 16 #51720](https://github.com/JuliaLang/julia/pull/51720)
- Add comment for `atomicrmw_ops`

TODO:
- [ ] Update CI
- [ ] Set version to `v"0.6.0"`?
