### PR TITLE
Throw an error in `checktask` when a task failed

### DIFF
--- a/src/threadtasks.jl
+++ b/src/threadtasks.jl
@@ -71,7 +71,7 @@ end
   t = TASKS[tid]
   if istaskfailed(t)
     initialize_task(tid)
-    return true
+    throw(TaskFailedException(t))
   end
   yield()
   false
@@ -90,4 +90,3 @@ end
   end
   false
 end
-

--- a/test/threadingutilities.jl
+++ b/test/threadingutilities.jl
@@ -77,14 +77,18 @@ end
     @test ThreadingUtilities.load(pointer(x), ThreadingUtilities.ThreadState) ==
           ThreadingUtilities.SPIN
   end
+  # Make all tasks error
   for tid ∈ eachindex(ThreadingUtilities.TASKS)
     launch_thread_copy!(tid, Float64[], Float64[])
   end
   sleep(1)
   @test all(istaskfailed, ThreadingUtilities.TASKS)
-  @test all(ThreadingUtilities.wait, eachindex(ThreadingUtilities.TASKS))
+  # Test that `wait` reports the error for each task
+  for tid in eachindex(ThreadingUtilities.TASKS)
+    @test_throws "This function throws if N == 0 for testing purposes." ThreadingUtilities.wait(tid)
+  end
+  # Test that none of the tasks are in the failed state
   @test !any(istaskfailed, ThreadingUtilities.TASKS)
   # test copy on the reinitialized tasks
   foreach(test_copy, eachindex(ThreadingUtilities.TASKS))
 end
-

--- a/test/threadingutilities.jl
+++ b/test/threadingutilities.jl
@@ -85,7 +85,7 @@ end
   @test all(istaskfailed, ThreadingUtilities.TASKS)
   # Test that `wait` reports the error for each task
   for tid in eachindex(ThreadingUtilities.TASKS)
-    @test_throws "This function throws if N == 0 for testing purposes." ThreadingUtilities.wait(tid)
+    @test_throws TaskFailedException ThreadingUtilities.wait(tid)
   end
   # Test that none of the tasks are in the failed state
   @test !any(istaskfailed, ThreadingUtilities.TASKS)


### PR DESCRIPTION
Solves https://github.com/JuliaSIMD/Polyester.jl/issues/153.

```julia
julia> @batch for j in axes(x, 2)
                  for i in 1:5
                      if i > 3 && j in (2, 4, 9)
                          error("some error")
                      end
                      x[i, j] = 1
                  end
              end
ERROR: TaskFailedException
Stacktrace:
 [1] checktask(tid::UInt32)
   @ ThreadingUtilities ~/.julia/dev/ThreadingUtilities/src/threadtasks.jl:74
 [2] wait
   @ ~/.julia/packages/ThreadingUtilities/3z3g0/src/threadtasks.jl:88 [inlined]
 [3] wait
   @ ~/.julia/packages/ThreadingUtilities/3z3g0/src/threadtasks.jl:81 [inlined]
 [4] macro expansion
   @ ~/.julia/packages/Polyester/eqrC9/src/batch.jl:257 [inlined]
 [5] _batch_no_reserve
   @ ~/.julia/packages/Polyester/eqrC9/src/batch.jl:168 [inlined]
 [6] batch(::var"#56#57", ::Val{…}, ::Tuple{}, ::Tuple{}, ::Tuple{…}, ::Static.StaticInt{…}, ::Static.StaticInt{…}, ::Polyester.NoLoop, ::Polyester.CombineIndices, ::Matrix{…})
   @ Polyester ~/.julia/packages/Polyester/eqrC9/src/batch.jl:334
 [7] top-level scope
   @ ~/.julia/packages/Polyester/eqrC9/src/closure.jl:456

    nested task error: some error
    Stacktrace:
     [1] error(s::String)
       @ Base ./error.jl:35
     [2] macro expansion
       @ ./REPL[25]:4 [inlined]
     [3] #56
       @ ~/.julia/packages/Polyester/eqrC9/src/closure.jl:309 [inlined]
     [4] (::Polyester.BatchClosure{var"#56#57", ManualMemory.Reference{Tuple{…}}, false, Tuple{}})(p::Ptr{UInt64})
       @ Polyester ~/.julia/packages/Polyester/eqrC9/src/batch.jl:11
     [5] _call
       @ ~/.julia/packages/ThreadingUtilities/3z3g0/src/threadtasks.jl:11 [inlined]
     [6] (::ThreadingUtilities.ThreadTask)()
       @ ThreadingUtilities ~/.julia/dev/ThreadingUtilities/src/threadtasks.jl:29
Some type information was truncated. Use `show(err)` to see complete types.
```
Note that https://github.com/JuliaSIMD/Polyester.jl/pull/154 should probably get merged first.