### PR TITLE
Add function `reinit_task`

### DIFF
--- a/src/threadtasks.jl
+++ b/src/threadtasks.jl
@@ -76,6 +76,17 @@ end
   yield()
   false
 end
+
+# Like checktask, but without throwing errors.
+# This is used in Polyester.reset_threads!().
+@noinline function reinit_task(tid)
+  t = TASKS[tid]
+  if istaskfailed(t)
+    initialize_task(tid)
+  end
+  yield()
+end
+
 # 1-based tid
 @inline tasktid(p::Ptr{UInt}) = (p - THREADPOOLPTR[]) ÷ (THREADBUFFERSIZE)
 @inline wait(tid::Integer) = wait(taskpointer(tid), tid)


### PR DESCRIPTION
https://github.com/JuliaSIMD/Polyester.jl/pull/154 caused Trixi.jl CI to freeze sometimes.
I don't have a MWE for this, but the solution is to only re-initialize failed tasks.

To summarize the previous developments:
- `ThreadingUtilities.checktask` did not throw an error, which means that threads with errors just failed silently (https://github.com/JuliaSIMD/Polyester.jl/issues/153).
- https://github.com/JuliaSIMD/ThreadingUtilities.jl/pull/54 changed this behavior to throw an error.
- `Polyester.reset_threads!` also used `checktask`, which now throws errors, so #154 changed this to call `ThreadingUtilities.initialize_task` instead of `checktask`. However, this initializes all tasks, not just the failed ones like before all of these PRs. Apparently, this can cause freezing.
- This PR adds `reinit_task`, which is the same as the old `checktask` and https://github.com/JuliaSIMD/Polyester.jl/pull/160 uses this in `reset_threads!`.