### PR TITLE
add compat setting for Documenter and remove strict keyword of makedocs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,8 +15,7 @@ makedocs(;
         "Home" => "index.md",
         "Public API" => "public-api.md",
         "Internals (Private)" => "internals.md",
-    ],
-    strict=true,
+    ]
 )
 
 deploydocs(;


### PR DESCRIPTION
Documenter.jl failed in https://github.com/JuliaSIMD/ThreadingUtilities.jl/pull/58 since the `strict` keyword argument has been removed from `makedocs`. I added a compat setting for Documenter.jl and removed this keyword.

@efaulhaber: Maybe you could review this as well?